### PR TITLE
Johan's feedback changes

### DIFF
--- a/_includes/head_custom.html
+++ b/_includes/head_custom.html
@@ -1,0 +1,1 @@
+<script type="text/javascript" src="{{ '/assets/js/custom.js' | relative_url }}"></script>

--- a/_sass/color_schemes/alloverse.scss
+++ b/_sass/color_schemes/alloverse.scss
@@ -25,4 +25,4 @@ $nav-child-link-color: $blue-200;
 
 $body-text-color: $allo-text-color-light;
 $body-heading-color: $allo-text-color-dark;
-$code-background-color: $allo-text-color-light;
+$code-background-color: #2B2B2B;

--- a/_sass/custom/code.scss
+++ b/_sass/custom/code.scss
@@ -1,0 +1,76 @@
+/*
+  Rogue (Jekyll's syntax highlighter) uses Pygment compatible styles.
+
+  This is Railscasts Theme; https://github.com/uraimo/pygments-vimstyles
+*/
+
+.highlight, .highlight pre, .highlight table { background: #2B2B2B; color: #E6E1DC; }
+.highlight .hll { background-color: #ffffcc; }
+.highlight .c { color: #BC9458; font-style: italic; } /* Comment */
+.highlight .err { color: #E6E1DC; } /* Error */
+.highlight .g { color: #E6E1DC; } /* Generic */
+.highlight .k { color: #CC7833; } /* Keyword */
+.highlight .l { color: #E6E1DC; } /* Literal */
+.highlight .n, .highlight .h { color: #E6E1DC; } /* Name */
+.highlight .o { color: #E6E1DC; } /* Operator */
+.highlight .x { color: #E6E1DC; } /* Other */
+.highlight .p { color: #E6E1DC; } /* Punctuation */
+.highlight .cm { color: #BC9458; font-style: italic; } /* Comment.Multiline */
+.highlight .cp { color: #CC7833; } /* Comment.Preproc */
+.highlight .c1 { color: #BC9458; font-style: italic; } /* Comment.Single */
+.highlight .cs { color: #BC9458; font-style: italic; } /* Comment.Special */
+.highlight .gd { color: #E6E1DC; background-color: #660000; } /* Generic.Deleted */
+.highlight .ge { color: #E6E1DC; } /* Generic.Emph */
+.highlight .gr { color: #FFFFFF; background-color: #990000; } /* Generic.Error */
+.highlight .gh { color: #FFFFFF; } /* Generic.Heading */
+.highlight .gi { color: #E6E1DC; background-color: #144212; } /* Generic.Inserted */
+.highlight .go { color: #E6E1DC; } /* Generic.Output */
+.highlight .gp { color: #E6E1DC; } /* Generic.Prompt */
+.highlight .gs { color: #E6E1DC; } /* Generic.Strong */
+.highlight .gu { color: #FFFFFF; } /* Generic.Subheading */
+.highlight .gt { color: #E6E1DC; } /* Generic.Traceback */
+.highlight .kc { color: #CC7833; } /* Keyword.Constant */
+.highlight .kd { color: #CC7833; } /* Keyword.Declaration */
+.highlight .kn { color: #CC7833; } /* Keyword.Namespace */
+.highlight .kp { color: #CC7833; } /* Keyword.Pseudo */
+.highlight .kr { color: #CC7833; } /* Keyword.Reserved */
+.highlight .kt { color: #DA4939; } /* Keyword.Type */
+.highlight .ld { color: #E6E1DC; } /* Literal.Date */
+.highlight .m { color: #A5C261; } /* Literal.Number */
+.highlight .s { color: #A5C261; } /* Literal.String */
+.highlight .na { color: #FFC66D; } /* Name.Attribute */
+.highlight .nb { color: #E6E1DC; } /* Name.Builtin */
+.highlight .nc { color: #E6E1DC; } /* Name.Class */
+.highlight .no { color: #6D9CBE; } /* Name.Constant */
+.highlight .nd { color: #E6E1DC; } /* Name.Decorator */
+.highlight .ni { color: #E6E1DC; } /* Name.Entity */
+.highlight .ne { color: #E6E1DC; } /* Name.Exception */
+.highlight .nf { color: #FFC66D; } /* Name.Function */
+.highlight .nl { color: #E6E1DC; } /* Name.Label */
+.highlight .nn { color: #E6E1DC; } /* Name.Namespace */
+.highlight .nx { color: #E6E1DC; } /* Name.Other */
+.highlight .py { color: #E6E1DC; } /* Name.Property */
+.highlight .nt { color: #CC7833; } /* Name.Tag */
+.highlight .nv { color: #D0D0FF; } /* Name.Variable */
+.highlight .ow { color: #E6E1DC; } /* Operator.Word */
+.highlight .w { color: #E6E1DC; } /* Text.Whitespace */
+.highlight .mf { color: #A5C261; } /* Literal.Number.Float */
+.highlight .mh { color: #A5C261; } /* Literal.Number.Hex */
+.highlight .mi { color: #A5C261; } /* Literal.Number.Integer */
+.highlight .mo { color: #A5C261; } /* Literal.Number.Oct */
+.highlight .sb { color: #A5C261; } /* Literal.String.Backtick */
+.highlight .sc { color: #A5C261; } /* Literal.String.Char */
+.highlight .sd { color: #A5C261; } /* Literal.String.Doc */
+.highlight .s2 { color: #A5C261; } /* Literal.String.Double */
+.highlight .se { color: #A5C261; } /* Literal.String.Escape */
+.highlight .sh { color: #A5C261; } /* Literal.String.Heredoc */
+.highlight .si { color: #A5C261; } /* Literal.String.Interpol */
+.highlight .sx { color: #A5C261; } /* Literal.String.Other */
+.highlight .sr { color: #A5C261; } /* Literal.String.Regex */
+.highlight .s1 { color: #A5C261; } /* Literal.String.Single */
+.highlight .ss { color: #A5C261; } /* Literal.String.Symbol */
+.highlight .bp { color: #E6E1DC; } /* Name.Builtin.Pseudo */
+.highlight .vc { color: #D0D0FF; } /* Name.Variable.Class */
+.highlight .vg { color: #D0D0FF; } /* Name.Variable.Global */
+.highlight .vi { color: #D0D0FF; } /* Name.Variable.Instance */
+.highlight .il { color: #A5C261; } /* Literal.Number.Integer.Long */

--- a/_sass/custom/custom.scss
+++ b/_sass/custom/custom.scss
@@ -18,7 +18,9 @@ $border-color: #f0f;
 
 $body-text-color: $allo-text-color-light;
 $body-heading-color: $allo-text-color-dark;
-$code-background-color: $allo-text-color-light;
+$code-background-color: #2B2B2B;
+
+@import "./code";
 
 body {
   font-family: "Open Sans", "Segoe UI", "Roboto", "Helvetica Neue", Arial,

--- a/assets/js/custom.js
+++ b/assets/js/custom.js
@@ -1,0 +1,10 @@
+document.addEventListener('DOMContentLoaded', function() {
+  // scroll active site nav item into view if it's not visible
+  const siteNav = document.getElementById('site-nav');
+  const active = siteNav.querySelector('.nav-list-link.active');
+  if (active) {
+    if (active.getBoundingClientRect().bottom > siteNav.getBoundingClientRect().bottom) {
+      active.scrollIntoView();
+    }
+  }
+});

--- a/concepts/architecture.md
+++ b/concepts/architecture.md
@@ -130,11 +130,13 @@ to spawn the given appliance.
 The alloplace server should then make the http(s) call to the given URL with a
 connection instruction json blob:
 
+```json-doc
     {
       "spawnInPlace": "alloplace://hostname:port",
       "onBehalfOf": (client identity),
       "query": (query params as-is from the alloapp url)
     }.
+```
 
 The http server receiving this request should then spawn a process for this
 agent and have it connect to the `spawnInPlace` URL. See [the implementation

--- a/index.md
+++ b/index.md
@@ -9,6 +9,16 @@ nav_order: 1
 ---
 
 # {{ page.title }}
+{: .no_toc }
+
+<details open markdown="block">
+  <summary>
+    Table of contents
+  </summary>
+  {: .text-delta }
+1. TOC
+{:toc}
+</details>
 
 Alloverse is an open platform for collaborative workspaces in 3D. It’s Gibson style Cyberspace, but for your day-to-day work and play, with your friends and colleagues. It’s a VR and AR platform for creating spaces, and for running real applications within those spaces, together with other people.
 

--- a/protocol-reference/components.md
+++ b/protocol-reference/components.md
@@ -20,7 +20,7 @@ entity if it has one; otherwise relative to the world origo.
 See [Coordinate System](coordinate-system) for an extended description of how
 things are positioned and oriented in Alloverse.
 
-```
+```json-doc
 "transform": {
   "matrix": [1.0,0.0,0.0,0.0, 0.0,1.0,0.0,0.0, 0.0,0.0,1.0,0.0, 0.0,0.0,0.0,1.0]
 }
@@ -38,7 +38,7 @@ but until we have assets, geometry is encoded in-line in entity description.
 
 You also need to implement the client asset callbacks in order to respond to asset requests in order to deliver the asset.
 
-```
+```json-doc
 "geometry": {
   "type": "asset",
   "name": "asset:sha256:d2a84f4b8b650937ec8f73cd8be2c74add5a911ba64df27458ed8229da804a26"
@@ -48,7 +48,7 @@ You also need to implement the client asset callbacks in order to respond to ass
 **If type is `hardcoded-model`**, you're using one of the models hard-coded
 into the visor. `name` is the name of the model.
 
-```
+```json-doc
 "geometry": {
   "type": "hardcoded-model",
   "name": "hand"
@@ -63,7 +63,7 @@ This is only recommended for debugging, and until we have geometry assets.
 - `uvs` is an optional list of lists, each sub-list containing the u, v texture coordinates at the corresponding vertex.
 - `triangles` is a required list of lists. Each sub-list is three integers, which are indices into the above arrays, forming a triangle.
 
-```
+```json-doc
 "geometry": {
   "type": "inline",
   "vertices": [[1.0, 1.0, 1.0], [2.0, 2.0, 2.0], [3.0, 3.0, 3.0], [4.0, 4.0, 4.0]],
@@ -79,7 +79,7 @@ This is only recommended for debugging, and until we have geometry assets.
 
 Defines the surface appearance of the component being rendered.
 
-```
+```json-doc
 "material": {
   "color": [1.0, 1.0, 0.0, 1.0],
   "shader_name": "plain",
@@ -95,7 +95,7 @@ Defines the surface appearance of the component being rendered.
 
 Defines a text renderer for this entity, drawing a text texture at `transform`.
 
-```
+```json-doc
 "text": {
   "string": "hello world",
   "height": 0.03,
@@ -112,7 +112,7 @@ Defines a text renderer for this entity, drawing a text texture at `transform`.
 
 Defines the physical shape of an entity.
 
-```
+```json-doc
 "collider": {
   "type": "box",
   "width": 1,
@@ -125,7 +125,7 @@ Defines the physical shape of an entity.
 
 Specify the relationships between entities, in particular child entites' "parent" entity. If an entity has a parent, its transform should be concatenated with all its ancestors' transforms before being displayed.
 
-```
+```json-doc
 "relationships": {
   "parent": "abc123"
 }
@@ -138,7 +138,7 @@ Specify how the entity's owning agent's intent affects this entity.
 - `actuate_pose`: this named pose will be set as this entity's transform each frame.
 - `from_avatar` (optional): Instead of following the owning agent's intents, follow the agent who has this entity as its avatar.
 
-```
+```json-doc
 "intent": {
   "actuate_pose": "hand/left",
   "from_avatar": "abc123"
@@ -153,7 +153,7 @@ moved/dragged by a user.
 The actual grabbing is accomplished using intents.
 See the field `grab` under [intent](intent).
 
-```
+```json-doc
 "grabbable": {
   "actuate_on": "...",
 
@@ -197,7 +197,7 @@ to `place` to add a `live-media` component to your entity.
 - `channel_count`: For audio: only 1 mono channel supported
 - `format`: Only "opus" audio supported
 
-```
+```json-doc
 "live_media": {
   "track_id": 0, // filled in by server
   "sample_rate": 48000, //
@@ -211,7 +211,7 @@ to `place` to add a `live-media` component to your entity.
 Only set on the entity `place`, this component defines the flow of time
 for a place.
 
-```
+```json-doc
 "clock": {
   "time": 123.0, // in seconds
 }
@@ -223,7 +223,7 @@ Its reference time is undefined. It is always seconds as a double.
 
 Defines a custom cursor renderer, controlling the appearence of the cursor displayed when pointing at the entity.
 
-```
+```json-doc
 "cursor": {
   "name": "brushCursor",
   "size": 3,

--- a/protocol-reference/index.md
+++ b/protocol-reference/index.md
@@ -41,7 +41,7 @@ across connections and places without a central identity authority server.
 
 Identity is currently expressed as the following JSON blob:
 
-```
+```json-doc
 {
     "display_name": "annie"
 }
@@ -55,7 +55,7 @@ else is specified as a set of components.
 
 JSON specification:
 
-```
+```json-doc
 {
     "id": "1234",
     "components": {
@@ -123,7 +123,7 @@ See [intent](intent).
 Sent from agent, to place, then forwarded to the designated agent,
 over the reliable channel on demand.
 
-```
+```json-doc
   [
     "interaction",
     "{oneway|request|response|publication}"
@@ -193,7 +193,7 @@ Interaction ACLs guard on the entire interaction message,
 and not just the payload body. So for example, the following
 rule would disallow users named "harry" from joining a room:
 
-```
+```json-doc
 [
   "deny",
   """[
@@ -217,7 +217,7 @@ expression.
 If an interaction is sent by an agent but is disallowed by an ACL
 rule, the following message is sent in response:
 
-```
+```json-doc
 [
   "interaction_denied",
   // original interaction goes here,

--- a/protocol-reference/intent.md
+++ b/protocol-reference/intent.md
@@ -14,7 +14,7 @@ and on the server at the server heart rate.
 
 Format of the packet on-wire today:
 
-```
+```json-doc
 {
   "cmd": "intent",
   "intent": {
@@ -58,7 +58,7 @@ To understand `ack_state_rev`, see (state.md)[state.md].
 
 Planned version of the packet:
 
-```
+```json-doc
 {
     "intents": {
         "{entity id of avatar}": {

--- a/protocol-reference/interactions.md
+++ b/protocol-reference/interactions.md
@@ -23,7 +23,7 @@ announce will lead to force disconnect.
 - Type: `request`
 - Request body:
 
-```
+```json-doc
 [
   "announce",
   "version",
@@ -41,7 +41,7 @@ announce will lead to force disconnect.
 
 - Response:
 
-```
+```json-doc
 [
   "announce",
   "{ID of avatar entity}",
@@ -55,7 +55,7 @@ announce will lead to force disconnect.
 - Type: `request`
 - Request body:
 
-```
+```json-doc
 [
   "spawn_entity",
   {
@@ -76,7 +76,7 @@ announce will lead to force disconnect.
 
 - Response:
 
-```
+```json-doc
 [
   "spawn_entity",
   "{ID of entity if spawned}"
@@ -89,7 +89,7 @@ announce will lead to force disconnect.
 - Type: `request`
 - Request body:
 
-```
+```json-doc
 [
   "remove_entity",
   "{ID of entity to remove}",
@@ -102,7 +102,7 @@ announce will lead to force disconnect.
 
 - Response:
 
-```
+```json-doc
 [
   "remove_entity",
   "ok"
@@ -115,7 +115,7 @@ announce will lead to force disconnect.
 - Type: `request`
 - Request body:
 
-```
+```json-doc
 [
   "change_components",
   "{entity ID}",
@@ -133,7 +133,7 @@ announce will lead to force disconnect.
 
 Response:
 
-```
+```json-doc
 [
   "change_components",
   "ok"
@@ -149,7 +149,7 @@ whose component you're changing, but this rule can be changed.
 - Type: `request`
 - Request body for subscribe:
 
-```
+```json-doc
 [
   "subscribe",
   """{guard pattern}"""
@@ -158,7 +158,7 @@ whose component you're changing, but this rule can be changed.
 
 - Response:
 
-```
+```json-doc
 [
   "subscribe",
   "{subscription ID}"
@@ -167,7 +167,7 @@ whose component you're changing, but this rule can be changed.
 
 - Unsubscribe request body:
 
-```
+```json-doc
 [
   "unsubscribe",
   "{subscription ID}"
@@ -176,7 +176,7 @@ whose component you're changing, but this rule can be changed.
 
 - Response:
 
-```
+```json-doc
 [
   "unsubscribe",
   "{'ok'|'not_subscribed'}"
@@ -185,7 +185,7 @@ whose component you're changing, but this rule can be changed.
 
 - Example:
 
-```
+```json-doc
   [
     "interaction",
     "request",
@@ -227,7 +227,7 @@ on itself someone is pointing.
 - Type: `one-way`
 - Body:
 
-```
+```json-doc
 [
   "point",
   [1.0, 2.0, 3.0], // finger tip in world space coordinates
@@ -239,7 +239,7 @@ If the ray cast from the user's finger veers off the last pointed-at
 entity, one last message is sent to indicate that the user has stopped
 pointing at it. This is useful for removing highlight effect, etc.
 
-```
+```json-doc
 [
   "point-exit"
 ]
@@ -259,7 +259,7 @@ sender's user can understand if and why poking failed.
 - Type: `request`
 - Request body:
 
-```
+```json-doc
 [
   "poke",
   {true|false} // whether poking started (true) or stopped (false)
@@ -268,7 +268,7 @@ sender's user can understand if and why poking failed.
 
 - Success response:
 
-```
+```json-doc
 [
   "poke",
   "ok"
@@ -277,7 +277,7 @@ sender's user can understand if and why poking failed.
 
 - Failure response:
 
-```
+```json-doc
 [
   "poke",
   "failed",
@@ -298,7 +298,7 @@ Only audio, and only mono opus, is supported right now.
 - Type: `request`
 - Request body:
 
-```
+```json-doc
 [
   "allocate_track",
   "audio", # media type
@@ -310,7 +310,7 @@ Only audio, and only mono opus, is supported right now.
 
 - Success response:
 
-```
+```json-doc
 [
   "allocate_track",
   "ok",
@@ -320,7 +320,7 @@ Only audio, and only mono opus, is supported right now.
 
 - Failure response:
 
-```
+```json-doc
 [
   "allocate_track",
   "failed",

--- a/protocol-reference/state.md
+++ b/protocol-reference/state.md
@@ -14,7 +14,7 @@ on unreliable channel 0.
 
 The world representation is stored as a big JSON document like so:
 
-```
+```json-doc
 {
   "entities": {
     "abc123": {
@@ -48,7 +48,7 @@ The packet on channel 0 received in the client can take three forms:
 
 If the server is unable to diff, it will just send the full world state document.
 
-```
+```json-doc
 {
   "patch_style": "set",
   "entities": ...,
@@ -64,7 +64,7 @@ the document is stored to history.
 Indicates that the payload is an [RFC 6902](https://tools.ietf.org/html/rfc6902)
 JSON Patch.
 
-```
+```json-doc
 {
   "patch_style": "apply",
   "patch_from": 1233,
@@ -88,7 +88,7 @@ so its support is likely to be removed.
 Indicates that the payload is an [RFC 7386](https://tools.ietf.org/html/rfc7396)
 JSON Merge Patch.
 
-```
+```json-doc
 {
   "patch_style": "merge",
   "patch_from": 1233,
@@ -109,7 +109,7 @@ you should set intent's `ack_state_rev` back to 0 to request a full `set` state.
 Version 1 sent the complete world-state as is, and with entities as an array rather
 than an object. It looked like this:
 
-```
+```json-doc
 entities: [
   // list of all entities; see Entities above for structure
 ],

--- a/protocol-reference/wire-protocol.md
+++ b/protocol-reference/wire-protocol.md
@@ -41,7 +41,7 @@ What are the actual bytes travelling on the wire? They all seem to be json paylo
 
 Version 0 implements this packet as:
 
-```
+```json-doc
 {
   "cmd": "interact",
   "interact": {
@@ -81,7 +81,7 @@ that stupid newline at the end.
 - Kind: Unreliable
 - Payload:
 
-```
+```json-doc
 {
   "client_clock": 123.0,
   "server_clock": 456.0


### PR DESCRIPTION
I decided to try and implement my feedback from [here](https://discord.com/channels/666632072076722187/685098079170723850/817780321281376257):

> 1. Color contrast in Lua code highlighting could be improved. Here: https://docs.alloverse.com/#building-our-app
> 2. ToC of page headers on a long page would be nice to improve navigation speed and scannability. The old adage "people don't read on the web - they scan" comes to mind. https://www.nngroup.com/articles/how-users-read-on-the-web/. Here: https://docs.alloverse.com/
> 3. JSON code highlighting perhaps... Here: https://docs.alloverse.com/protocol-reference/official-components
> 4. I like the initial class/method docs. I like that everything has "anchor-links" (I don't remember the correct term). Here: https://docs.alloverse.com/doc/classes/Asset.html
> 5. Navigating between the bottom links like "allonet.src.server", "alloui.lua.alloui.json" is annoying because it scrolls you to the top everytime in the navigation list

No worries if you're not interested! It was a fun, small weekend task to do either way.

Feel free to adapt and make your own changes of course.

## 1. Color contrast in code highlighting

Tried out another code highlighter theme. Before vs after:

<img src="https://user-images.githubusercontent.com/22144/110219083-63032000-7ebd-11eb-8f93-6d4bf2d6415e.jpg" width="49%" /> <img src="https://user-images.githubusercontent.com/22144/110219031-22a3a200-7ebd-11eb-8514-e7e21ffe9aeb.jpg" width="49%" />

This is the Railscasts theme. Here's some links to find other Pygment themes:

https://stylishthemes.github.io/Syntax-Themes/pygments/
https://richleland.github.io/pygments-css/
http://help.farbox.com/pygments.html
https://jwarby.github.io/jekyll-pygments-themes/languages/javascript.html
https://github.com/uraimo/pygments-vimstyles

## 2. ToC of page headers on a long page would be nice

Tried out ["In-page navigation with Table of Contents"](https://pmarsceill.github.io/just-the-docs/docs/navigation-structure/#in-page-navigation-with-table-of-contents) on 1 page.

The [Android docs](https://developer.android.com/guide/topics/ui/notifiers/notifications) do it better, but I think this is a nice improvement.

![Image 2021-03-06 at 8 52 39 PM](https://user-images.githubusercontent.com/22144/110219170-ed4b8400-7ebd-11eb-944d-c4a5f343093d.jpg)

## 3. JSON code highlighting

Language tag `json-doc` works pretty well:

<img src="https://user-images.githubusercontent.com/22144/110219315-baee5680-7ebe-11eb-98be-980cc023b1e2.jpg" width="50%" />

## 5. Navigating between the bottom links is annoying because it scrolls you to the top

I added a small JS-snippet to scroll the active item into view on page load.

Once again, the [Android docs](https://developer.android.com/guide/topics/ui/notifiers/notifications) do it better. They seem to be using a solution similar to [Pjax](https://github.com/defunkt/jquery-pjax) or [Turbolinks](https://github.com/turbolinks/turbolinks).